### PR TITLE
Added magic tool

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,2 @@
+Scripts to run the tools. If they have a GUI, it's accessible here `http://localhost:6901/?password=magic`. To connect with an different VNC client, connect to localhost:5901 with the password "magic". The session is closed once the program being run is closed.
+The tools are run using docker, so it must be installed. To run the GUI tools without going through VNC, install the tools locally.

--- a/tools/magic.sh
+++ b/tools/magic.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker run -d -p 5901:5901 -p 6901:6901 bolunthompson/magic-vlsi


### PR DESCRIPTION
This is the [magic](http://opencircuitdesign.com/magic/) VLSI tool. Other GUI tools should be able to be added with docker in the same way, though I was having weird issues with the qflow GUI. [Repo](https://github.com/BolunThompson/docker-vlsi-tools).